### PR TITLE
ci: add doc build, split test and fmt jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,14 @@ name: Build
 on:
   push:
     branches: [ main ]
+    paths:
+      - '**.rs'
+      - 'Cargo.toml'
   pull_request:
     branches: [ main ]
+    paths:
+      - '**.rs'
+      - 'Cargo.toml'
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   build:
-    name: Build
+    name: Build lib
     strategy:
       matrix:
         rust: [
@@ -35,3 +35,24 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: build
+
+  doc:
+    name: Build doc
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install Rust Nightly
+      uses: actions-rs/toolchain@v1.0.7
+      with:
+        toolchain: nightly
+        override: true
+        profile: minimal
+
+    - uses: Swatinem/rust-cache@v2.0.0
+
+    - name: Build
+      uses: actions-rs/cargo@v1
+      with:
+        command: doc
+        args: --all-features --no-deps

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -1,0 +1,27 @@
+name: Fmt
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - '**.md'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - '**.md'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  mdfmt:
+    name: Generic format (md)
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Run dprint
+      run: |
+        curl -fsSL https://dprint.dev/install.sh | sh
+        /home/runner/.dprint/bin/dprint check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,18 +34,6 @@ jobs:
         command: clippy
         args: --workspace --all-targets --all-features -- -D warnings
 
-  mdfmt:
-    name: Generic format (md)
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v3
-
-    - name: Run dprint
-      run: |
-        curl -fsSL https://dprint.dev/install.sh | sh
-        /home/runner/.dprint/bin/dprint check
-
   test:
     name: Test
     runs-on: ubuntu-latest


### PR DESCRIPTION
We build lib and doc only on src changes. Fmt jobs runs only on .md changes.