### PR TITLE
Feat: Add proxy arg to client creation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ hex = "0.4"
 http = "0.2"
 jsonrpc-core = "18"
 monero = { version = "0.17", features = ["serde"] }
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { version = "0.11", features = ["json", "socks"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,12 +83,24 @@ pub struct LwsRpcClient {
 }
 
 impl LwsRpcClient {
-    pub fn new(addr: String) -> Self {
-        Self {
-            inner: CallerWrapper(Arc::new(RemoteCaller {
-                http_client: reqwest::ClientBuilder::new().build().unwrap(),
-                addr,
-            })),
+    pub fn new(addr: String, proxy: Option<String>) -> Self {
+        if let Some(proxy_address) = proxy {
+            Self {
+                inner: CallerWrapper(Arc::new(RemoteCaller {
+                    http_client: reqwest::Client::builder()
+                        .proxy(reqwest::Proxy::all(proxy_address).unwrap())
+                        .build()
+                        .unwrap(),
+                    addr,
+                })),
+            }
+        } else {
+            Self {
+                inner: CallerWrapper(Arc::new(RemoteCaller {
+                    http_client: reqwest::ClientBuilder::new().build().unwrap(),
+                    addr,
+                })),
+            }
         }
     }
 

--- a/tests/rpc.rs
+++ b/tests/rpc.rs
@@ -83,6 +83,6 @@ async fn setup_monero() -> (
 
     regtest.generate_blocks(100, address).await.unwrap();
     let dhost = env::var("MONERO_DAEMON_HOST").unwrap_or_else(|_| "localhost".into());
-    let lws_client = monero_lws::LwsRpcClient::new(format!("http://{}:38884", dhost));
+    let lws_client = monero_lws::LwsRpcClient::new(format!("http://{}:38884", dhost), None);
     (address, viewkey, lws_client, regtest)
 }


### PR DESCRIPTION
Allowing the user to specify a proxy, is useful to allow him to connect to a server through tor, analyze the traffic, or go through any number of anonymising services.